### PR TITLE
Chore/Update JavaScript dependencies.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -28,6 +28,7 @@ module.exports = function(api) {
       (isProductionEnv || isDevelopmentEnv) && [
         require('@babel/preset-env').default,
         {
+          corejs: 3,
           forceAllTransforms: true,
           useBuiltIns: 'entry',
           modules: false,
@@ -37,6 +38,7 @@ module.exports = function(api) {
       [
         require('@babel/preset-react').default,
         {
+          corejs: 3,
           development: isDevelopmentEnv || isTestEnv,
           useBuiltIns: true
         }
@@ -56,6 +58,7 @@ module.exports = function(api) {
       [
         require('@babel/plugin-proposal-object-rest-spread').default,
         {
+          corejs: 3,
           useBuiltIns: true
         }
       ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^4.3.1",
     "commonmark": "^0.29.1",
     "connected-react-router": "^6.5.2",
+    "core-js": "^3.6.5",
     "cross-fetch": "^3.0.2",
     "handlebars": "^4.5.3",
     "history": "^4.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,7 +3236,7 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-js@^3.4.0:
+core-js@^3.4.0, core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==


### PR DESCRIPTION
- Upgrade `serialize-javascript` (see CVE-2020-7660).
- Resolve `useBuiltIns` Babel warning.